### PR TITLE
Wait for the font window to open

### DIFF
--- a/notepad.robot
+++ b/notepad.robot
@@ -18,6 +18,7 @@ Change Font Settings
     Set Task Variable    ${fontstyle}    %{NOTEPAD_FONT_STYLE=Regular}
     Menu Select    Format->Font
     Refresh Window    # because UI changed
+    Wait For Element  name:\'Font style:\' and type:Edit
     Mouse Click    name:\'Font style:\' and type:Edit
     Send Keys    ${fontstyle}
     Mouse Click    name:Size: and class:Edit


### PR DESCRIPTION
The test seems to be flaky when run in slow cloud instance. The error happens always when opening the font windows. I added the wait for element keyword after the refresh page to make sure the element is found, even with slower instances.